### PR TITLE
Fix OBS build

### DIFF
--- a/butt.spec
+++ b/butt.spec
@@ -52,8 +52,8 @@ Source0:        http://downloads.sourceforge.net/%{name}/%{name}-%{version}.tar.
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  fltk-devel
-BuildRequires:  portaudio-devel
 BuildRequires:  libsamplerate-devel
+BuildRequires:  portaudio-devel
 
 %if %{with aac}
 BuildRequires:  fdk-aac-devel

--- a/butt.spec
+++ b/butt.spec
@@ -23,8 +23,8 @@
 #
 
 # Conditional build support
-# add --with aac option, i.e. disable AAC by default
-%bcond_with aac
+# add --without aac option, i.e. enable AAC by default
+%bcond_without aac
 
 # add --without flac option, i.e. enable FLAC by default
 %bcond_without flac
@@ -53,6 +53,7 @@ Source0:        http://downloads.sourceforge.net/%{name}/%{name}-%{version}.tar.
 BuildRequires:  desktop-file-utils
 BuildRequires:  fltk-devel
 BuildRequires:  portaudio-devel
+BuildRequires:  libsamplerate-devel
 
 %if %{with aac}
 BuildRequires:  fdk-aac-devel


### PR DESCRIPTION
Activate and install fdk-aac per default since the build process
doesn't have an easy way to deactivate this. This doesn't fix
disabling of aac in the builds but we have enough of nux-dextop
available right now for this to be pull-offable.

Fixes #1 