### PR TITLE
Version bump to 0.1.18

### DIFF
--- a/butt.spec
+++ b/butt.spec
@@ -42,7 +42,7 @@
 %global iconsdir %{_datadir}/icons
 
 Name:           butt
-Version:        0.1.17
+Version:        0.1.18
 Release:        1%{?dist}
 Summary:        butt is an easy to use, multi OS streaming tool
 
@@ -155,6 +155,9 @@ fi
 
 
 %changelog
+* Sun May 12 2019 Christian Affolter <c.affolter@purplehaze.ch> - 0.1.18-1
+- Bump to 0.1.18
+
 * Tue Apr 16 2019 Lucas Bickel <hairmare@rabe.ch> - 0.1.17-1
 - Bump to 0.1.17
 - Disable AAC in default build

--- a/butt.spec
+++ b/butt.spec
@@ -1,8 +1,8 @@
 #
 # spec file for package butt
 #
-# Copyright (c) 2017 Radio Bern RaBe
-#                    http://www.rabe.ch
+# Copyright (c) 2017 - 2019 Radio Bern RaBe
+#                           http://www.rabe.ch
 #
 # This program is free software: you can redistribute it and/or
 # modify it under the terms of the GNU Affero General Public 


### PR DESCRIPTION
Version bump to 0.1.18

Upstream release announcement and changelog:
* https://sourceforge.net/p/butt/news/2019/04/new-release-butt-0118/
* http://danielnoethen.de/Changelog.html#_version_0_1_18_2019_05_12